### PR TITLE
Fix .gov.uk references to .gov.au references.

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -27,7 +27,7 @@
   <ul>
     <li><a href="/terms-and-conditions" class="terms-and-conditions">Terms and conditions</a></li>
     <li><a href="/cookies">Cookies</a></li>
-    <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
+    <li>Built by the <a href="https://www.dto.gov.au/">Digital Transformation Office</a></li>
   </ul>
 {% endblock %}
 

--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -5,7 +5,7 @@
     </h2>
     <ul>
       <li>
-        <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">Digital Marketplace support</a>
+        <a href="mailto:enquiries@digitalmarketplace.gov.au">Digital Marketplace support</a>
       </li>
     </ul>
   </div>
@@ -15,22 +15,22 @@
     </h2>
     <ul>
       <li>
-        <a href="https://www.gov.uk/government/collections/digital-marketplace-buyers-and-suppliers-information">Digital Marketplace information</a>
+        <a href="#">Digital Marketplace information</a>
       </li>
       <li>
-        <a href="https://digitalmarketplace.blog.gov.uk">Digital Marketplace blog</a>
+        <a href="#">Digital Marketplace blog</a>
       </li>
       <li>
-        <a href="https://www.gov.uk/guidance/the-g-cloud-framework-on-the-digital-marketplace">G-Cloud framework</a>
+        <a href="#">G-Cloud framework</a>
       </li>
       <li>
           <a href="{{ url_for('main.suppliers_list_by_prefix') }}">G-Cloud supplier A–Z</a>
       </li>
       <li>
-        <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>
+        <a href="#">Crown Hosting framework</a>
       </li>
       <li>
-        <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
+        <a href="#">Crown Commercial Service</a>
       </li>
     </ul>
     </div>
@@ -40,25 +40,25 @@
         </h2>
         <ul>
             <li>
-                <a href="https://www.gov.uk/guidance/digital-marketplace-buyers-guide">Digital Marketplace buyers’ guide</a>
+                <a href="#">Digital Marketplace buyers’ guide</a>
             </li>
             <li>
-                <a href="https://www.gov.uk/guidance/digital-marketplace-suppliers-guide">Digital Marketplace suppliers’ guide</a>
+                <a href="#">Digital Marketplace suppliers’ guide</a>
             </li>
             <li>
-                <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide">G-Cloud buyers’ guide</a>
+                <a href="#">G-Cloud buyers’ guide</a>
             </li>
             <li>
-                <a href="https://www.gov.uk/guidance/g-cloud-suppliers-guide">G-Cloud suppliers’ guide</a>
+                <a href="#">G-Cloud suppliers’ guide</a>
             </li>
             <li>
-                <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">Digital Outcomes and Specialists buyers’ guide</a>
+                <a href="#">Digital Outcomes and Specialists buyers’ guide</a>
             </li>
             <li>
-                <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">Digital Outcomes and Specialists user research labs buyers' guide</a>
+                <a href="#">Digital Outcomes and Specialists user research labs buyers' guide</a>
             </li>
             <li>
-                <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">Digital Outcomes and Specialists suppliers’ guide</a>
+                <a href="#">Digital Outcomes and Specialists suppliers’ guide</a>
             </li>
         </ul>
     </div>

--- a/app/templates/_phase_banner.html
+++ b/app/templates/_phase_banner.html
@@ -1,6 +1,6 @@
 
 <div class="phase-banner">
   <p>
-     <strong class="phase-tag">BETA</strong> This is a <a href="https://www.gov.uk/help/beta">beta service</a>  – please send your feedback to  <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+     <strong class="phase-tag">BETA</strong> This is a <a href="#">beta service</a>  – please send your feedback to  <a href="mailto:enquiries@digitalmarketplace.gov.au?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.gov.au">enquiries@digitalmarketplace.gov.au</a>
   </p>
 </div>

--- a/app/templates/auth/create-buyer-user-error.html
+++ b/app/templates/auth/create-buyer-user-error.html
@@ -20,7 +20,7 @@
   <div>
     <p>
       <a href="{{ url_for('.create_buyer_account') }}">Create an account using a different email address</a> or email
-      <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.gov.au</a> if:
+      <a href="mailto:enquiries@digitalmarketplace.gov.au">enquiries@digitalmarketplace.gov.au</a> if:
     </p>
     <ul>
       <li>
@@ -40,7 +40,7 @@
   <p>
     The link you used to create an account may have expired.<br/>
     Check you’ve entered the correct link or <a href="{{ url_for('.create_buyer_account') }}">send a new one</a>.<br/>
-    If you still can’t create an account, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+    If you still can’t create an account, email <a href="mailto:enquiries@digitalmarketplace.gov.au">enquiries@digitalmarketplace.gov.au</a>
   </p>
 
 {% elif user %}
@@ -51,7 +51,7 @@
       <h1>Your account has been deactivated.</h1>
     </header>
     <p>
-      Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to reactivate your account.
+      Email <a href="mailto:enquiries@digitalmarketplace.gov.au">enquiries@digitalmarketplace.gov.au</a> to reactivate your account.
     </p>
   
   {% elif user.locked %}
@@ -60,7 +60,7 @@
       <h1>Your account has been locked.</h1>
     </header>
     <p>
-      Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to unlock your account.
+      Email <a href="mailto:enquiries@digitalmarketplace.gov.au">enquiries@digitalmarketplace.gov.au</a> to unlock your account.
     </p>
 
   {% elif user.role == 'supplier' %}
@@ -70,7 +70,7 @@
     </header>
     <p>Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
     <p>You can <a href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
-      <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to have your account
+      <a href="mailto:enquiries@digitalmarketplace.gov.au">enquiries@digitalmarketplace.gov.au</a> to have your account
       converted to a buyer account.</p>
     <p>
       Alternatively, <a href="{{ url_for('.render_login') }}">Log in</a> to your {{ user.supplier_name }} account.

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -19,7 +19,7 @@
         Make sure you've entered the right email address and password.
         Accounts are locked after 5 failed attempts. If you think your
         account has been locked, email
-        <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
+        <a href="mailto:enquiries@digitalmarketplace.gov.au">enquiries@digitalmarketplace.gov.au</a>.
       </p>
     {% elif message == 'password_updated' %}
       <p class="callout">

--- a/app/templates/emails/reset_password_email.html
+++ b/app/templates/emails/reset_password_email.html
@@ -11,7 +11,7 @@ You recently asked to reset your Digital Marketplace password.
 <br /><br />
 {% if locked %}
 It looks like you failed to log in 5 times so your account has now been locked.
-Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to unlock it.
+Email <a href="mailto:enquiries@digitalmarketplace.gov.au">enquiries@digitalmarketplace.gov.au</a> to unlock it.
 <br /><br />
 {% else %}
 You can change your password now using the link below:


### PR DESCRIPTION
1. Correct HTML templates from .gov.uk to .gov.au
2. Correct email templates from .gov.uk to .gov.au