### PR TITLE
Don't use a hardcoded URL for the search page

### DIFF
--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -142,7 +142,7 @@ def supplier_search():
     return render_template(
         'search_suppliers.html',
         title='Supplier Catalogue',
-        search_url='/search/suppliers',
+        search_url=url_for('.supplier_search'),
         search_keywords='',
         filters=filters,
         num_results=num_results,


### PR DESCRIPTION
This broke when the site was moved (issue #16)