### PR TITLE
Sort supplier categories on the supplier catalogue page

### DIFF
--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -137,7 +137,7 @@ def supplier_search():
             details['name'],
             details['summary'],
             [Badge('badge-security', 'Security clearance'), Badge('badge-tick', 'ABC compliant')],
-            supplier_roles,
+            sorted(supplier_roles),
             [ExtraDetail('Location', '%s, %s' % (details['address']['suburb'], details['address']['state'])),
              ],
             url_for('.get_supplier', code=details['code']))


### PR DESCRIPTION
Categories are sorted alphabetically on the supplier page, this
adds the same sorting to the supplier info on the catalogue page.