### PR TITLE
Revert "Add a temporary login requirement for the supplier catalogue"

### DIFF
--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -3,7 +3,6 @@ import json
 from flask.helpers import url_for
 import os
 from flask import abort, render_template, request, redirect, current_app
-from flask_login import login_required
 from app.api_client.data import DataAPIClient
 from app.main.utils import get_page_list
 
@@ -23,7 +22,6 @@ Result = namedtuple('Result', 'title description badges roles url')
 
 
 @main.route('/search/suppliers')
-@login_required  # TODO Remove for go-live
 def supplier_search():
     sort_order = request.args.get('sort_order', 'asc')  # asc or desc
     sort_terms = request.args.getlist('sort_term')


### PR DESCRIPTION
Catalogue login requirement was temporary, we don't want it on the live service.

This reverts commit 0b25f291b97b0dbdb0d2828bf68b7c63d49b02e8.

**NOTE** We don't want this to go to live just yet (but we need it to do a run-through on dev), so merging this early will probably block releases to live until we're close to the launch time.