### PR TITLE
Fix up form validation for buyer account invite/creation

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,7 +1,7 @@
 from wtforms import PasswordField
 from wtforms.fields.core import BooleanField
 from wtforms.validators import DataRequired, EqualTo, Length, Regexp
-from dmutils.forms import StripWhitespaceStringField, StringField, DmForm, email_regex is_government_email
+from dmutils.forms import StripWhitespaceStringField, StringField, DmForm, email_regex, is_government_email
 
 from app import data_api_client
 
@@ -71,9 +71,14 @@ class BuyerInviteRequestForm(DmForm):
     )
 
 
-class BuyerSignupEmailForm(EmailAddressForm):
-    government_emp_checkbox = BooleanField(label='I am a public service employee or have authorisation, \
-        as described above.', validators=[DataRequired(message="You must check the checkbox")])
+class BuyerSignupEmailForm(DmForm):
+    email_address = StripWhitespaceStringField(
+        'Email', id="input_email_address",
+        validators=[
+            DataRequired(message="You must provide an email address"),
+            is_government_email(data_api_client)
+        ]
+    )
 
 
 class ChangePasswordForm(DmForm):

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,7 +1,9 @@
 from wtforms import PasswordField
 from wtforms.fields.core import BooleanField
 from wtforms.validators import DataRequired, EqualTo, Length, Regexp
-from dmutils.forms import StripWhitespaceStringField, StringField, DmForm, email_regex
+from dmutils.forms import StripWhitespaceStringField, StringField, DmForm, email_regex is_government_email
+
+from app import data_api_client
 
 
 class LoginForm(DmForm):
@@ -30,7 +32,15 @@ class EmailAddressForm(DmForm):
     )
 
 
-class BuyerInviteRequestForm(EmailAddressForm):
+class BuyerInviteRequestForm(DmForm):
+    email_address = StripWhitespaceStringField(
+        'Email', id="input_email_address",
+        validators=[
+            DataRequired(message="You must provide an email address"),
+            is_government_email(data_api_client)
+        ]
+    )
+
     government_emp_checkbox = BooleanField(label='I am a public service employee or have authorisation, \
         as described above.', validators=[DataRequired(message="You must check the checkbox")])
 
@@ -52,7 +62,7 @@ class BuyerInviteRequestForm(EmailAddressForm):
         'Manager email address', id='manager_email',
         validators=[
             DataRequired(message='You must provide your manager\'s email address'),
-            email_regex,
+            is_government_email(data_api_client)
         ]
     )
 

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,7 +1,7 @@
 from wtforms import PasswordField
 from wtforms.fields.core import BooleanField
 from wtforms.validators import DataRequired, EqualTo, Length, Regexp
-from dmutils.forms import StripWhitespaceStringField, StringField, DmForm, email_regex, is_government_email
+from dmutils.forms import StripWhitespaceStringField, StringField, DmForm, email_validator, government_email_validator
 
 from app import data_api_client
 
@@ -11,7 +11,7 @@ class LoginForm(DmForm):
         'Email', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            email_regex,
+            email_validator,
         ]
     )
     password = PasswordField(
@@ -27,7 +27,7 @@ class EmailAddressForm(DmForm):
         'Email', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            email_regex,
+            email_validator,
         ]
     )
 
@@ -37,7 +37,7 @@ class BuyerInviteRequestForm(DmForm):
         'Email', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            is_government_email(data_api_client)
+            government_email_validator,
         ]
     )
 
@@ -62,7 +62,7 @@ class BuyerInviteRequestForm(DmForm):
         'Manager email address', id='manager_email',
         validators=[
             DataRequired(message='You must provide your manager\'s email address'),
-            is_government_email(data_api_client)
+            government_email_validator,
         ]
     )
 
@@ -76,7 +76,7 @@ class BuyerSignupEmailForm(DmForm):
         'Email', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            is_government_email(data_api_client)
+            government_email_validator,
         ]
     )
 

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -192,7 +192,6 @@ def buyer_invite_request():
 def submit_buyer_invite_request():
     form = BuyerInviteRequestForm(request.form)
 
-    # TODO: add buyer domain whitelisting to form validation
     if not form.validate():
         return render_template_with_csrf(
             'auth/buyer-invite-request.html',
@@ -236,45 +235,38 @@ def submit_create_buyer_account():
 
     if form.validate():
         email_address = form.email_address.data
-        # TODO: add buyer domain whitelisting to form validation
-        if not data_api_client.is_email_address_with_valid_buyer_domain(email_address):
-            return render_template_with_csrf(
-                "auth/create-buyer-user-error.html",
-                status_code=400,
-                error='invalid_buyer_domain')
-        else:
-            token = generate_token(
-                {
-                    "email_address":  email_address
-                },
-                current_app.config['SHARED_EMAIL_KEY'],
-                current_app.config['INVITE_EMAIL_SALT']
+        token = generate_token(
+            {
+                "email_address":  email_address
+            },
+            current_app.config['SHARED_EMAIL_KEY'],
+            current_app.config['INVITE_EMAIL_SALT']
+        )
+        url = url_for('main.create_user', encoded_token=token, _external=True)
+        email_body = render_template("emails/create_buyer_user_email.html", url=url)
+        try:
+            send_email(
+                email_address,
+                email_body,
+                current_app.config['CREATE_USER_SUBJECT'],
+                current_app.config['RESET_PASSWORD_EMAIL_FROM'],
+                current_app.config['RESET_PASSWORD_EMAIL_NAME'],
             )
-            url = url_for('main.create_user', encoded_token=token, _external=True)
-            email_body = render_template("emails/create_buyer_user_email.html", url=url)
-            try:
-                send_email(
-                    email_address,
-                    email_body,
-                    current_app.config['CREATE_USER_SUBJECT'],
-                    current_app.config['RESET_PASSWORD_EMAIL_FROM'],
-                    current_app.config['RESET_PASSWORD_EMAIL_NAME'],
-                )
-                session['email_sent_to'] = email_address
-            except EmailError as e:
-                current_app.logger.error(
-                    "buyercreate.fail: Create user email failed to send. "
-                    "error {error} email_hash {email_hash}",
-                    extra={
-                        'error': six.text_type(e),
-                        'email_hash': hash_email(email_address)})
-                abort(503, response="Failed to send user creation email.")
+            session['email_sent_to'] = email_address
+        except EmailError as e:
+            current_app.logger.error(
+                "buyercreate.fail: Create user email failed to send. "
+                "error {error} email_hash {email_hash}",
+                extra={
+                    'error': six.text_type(e),
+                    'email_hash': hash_email(email_address)})
+            abort(503, response="Failed to send user creation email.")
 
-            data_api_client.create_audit_event(
-                audit_type=AuditTypes.invite_user,
-                data={'invitedEmail': email_address})
+        data_api_client.create_audit_event(
+            audit_type=AuditTypes.invite_user,
+            data={'invitedEmail': email_address})
 
-            return redirect(url_for('.create_your_account_complete'), 302)
+        return redirect(url_for('.create_your_account_complete'), 302)
     else:
         return render_template_with_csrf(
             "auth/create-buyer-account.html",
@@ -352,7 +344,7 @@ def submit_create_user(encoded_token):
             login_user(user)
 
         except HTTPError as e:
-            if e.message != 'invalid_buyer_domain' and e.status_code != 409:
+            if e.status_code != 409:
                 raise
 
             return render_template_with_csrf(

--- a/app/templates/auth/buyer-invite-request.html
+++ b/app/templates/auth/buyer-invite-request.html
@@ -20,6 +20,18 @@
     </ul>
   </div>
 {% endif %}
+{% if form.email_address.flags.non_gov or form.manager_email.flags.non_gov %}
+<div>
+  <h2>You and your manager need a government email address</h2>
+  <p>
+    Email addresses must end with <strong>.gov.au</strong>.
+  </p>
+  <p>
+    If you believe your email address should be recognised email
+    <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>.
+  </p>
+<div>
+{% endif %}
 
 {%
   with

--- a/app/templates/auth/create-buyer-account.html
+++ b/app/templates/auth/create-buyer-account.html
@@ -5,21 +5,6 @@
 
 {% block phase_banner %}{% endblock %}
 
-{#
-{% block breadcrumb %}
-{%
-  with items = [
-    {
-    "link": "/",
-    "label": "Digital Marketplace"
-    }
-  ]
-%}
-{% include "toolkit/breadcrumb.html" %}
-{% endwith %}
-{% endblock %}
-#}
-
 {% block body_classes %} registration-pages form-page{% endblock %}
 {% block main_content %}
 
@@ -44,24 +29,8 @@
 {% include "toolkit/page-heading.html" %}
 {% endwith %}
 
-<p>
-  Please confirm you are:
-</p>
-<ul>
-  <li>an employee under the Public Service Act 1999 (Cth) or</li>
-  <li>an employee under the equivalent State or Territory legislation or</li>
-  <li>
-    have written authorisation from an employee under the Public Service Act 1999 (Cth) or an employee under the equivalent State or Territory legislation to act on behalf of a Commonwealth, State or Territory agency.
-  </li>
-</ul>
-
 <form method="POST" action="{{ url_for('.submit_create_buyer_account') }}">
   {{ form.csrf_token }}
-
-  <fieldset class="{% if form.government_emp_checkbox.errors[0] %}invalid{% endif %}">
-      {{ form.government_emp_checkbox }}
-      {{ form.government_emp_checkbox.label }}
-  </fieldset>
 
   {%
     with

--- a/app/templates/auth/create-buyer-user-error.html
+++ b/app/templates/auth/create-buyer-user-error.html
@@ -7,25 +7,7 @@
 {% block body_classes %} registration-pages form-page {% endblock %}
 {% block main_content %}
 
-{% if error == 'invalid_buyer_domain' %}
-
-  <header>
-    <h1>You need a government email address</h1>
-  </header>
-  <p>
-    To create an account you must have an email address ending in <strong>.gov.au</strong>.
-  </p>
-  <div>
-    <p>
-      <a href="{{ url_for('.create_buyer_account') }}">Try again with a different email address</a>.
-    </p>
-    <p>
-      Or if you believe your email address should be recognised email
-      <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>.
-    </p>
-  </div>
-
-{% elif not token %}
+{% if not token %}
 
   <header>
     <h1>Expired link</h1>

--- a/config.py
+++ b/config.py
@@ -54,7 +54,8 @@ class Config(object):
     RESET_PASSWORD_EMAIL_SUBJECT = 'Reset your Digital Marketplace password'
 
     BUYER_INVITE_REQUEST_SUBJECT = 'Buyer Account Invite Request'
-    BUYER_INVITE_REQUEST_ADMIN_EMAIL = 'marketplace+buyer-request@digital.gov.au'
+    #BUYER_INVITE_REQUEST_ADMIN_EMAIL = 'marketplace+buyer-request@digital.gov.au'#
+    BUYER_INVITE_REQUEST_ADMIN_EMAIL = 'simon.arneaud@digital.gov.au'
     BUYER_INVITE_REQUEST_EMAIL_FROM = DM_GENERIC_NOREPLY_EMAIL
     BUYER_INVITE_REQUEST_EMAIL_NAME = DM_GENERIC_ADMIN_NAME
 

--- a/config.py
+++ b/config.py
@@ -54,8 +54,7 @@ class Config(object):
     RESET_PASSWORD_EMAIL_SUBJECT = 'Reset your Digital Marketplace password'
 
     BUYER_INVITE_REQUEST_SUBJECT = 'Buyer Account Invite Request'
-    #BUYER_INVITE_REQUEST_ADMIN_EMAIL = 'marketplace+buyer-request@digital.gov.au'#
-    BUYER_INVITE_REQUEST_ADMIN_EMAIL = 'simon.arneaud@digital.gov.au'
+    BUYER_INVITE_REQUEST_ADMIN_EMAIL = 'marketplace+buyer-request@digital.gov.au'
     BUYER_INVITE_REQUEST_EMAIL_FROM = DM_GENERIC_NOREPLY_EMAIL
     BUYER_INVITE_REQUEST_EMAIL_NAME = DM_GENERIC_ADMIN_NAME
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 Werkzeug==0.11.10
 
-git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@24.4.1#egg=dto-digitalmarketplace-utils==24.4.1
+git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@24.5.0#egg=dto-digitalmarketplace-utils==24.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 Werkzeug==0.11.10
 
-git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@24.5.0#egg=dto-digitalmarketplace-utils==24.5.0
+git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@25.0.1#egg=dto-digitalmarketplace-utils==25.0.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
 

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -610,7 +610,6 @@ class TestBuyerInviteRequest(BaseApplicationTest):
     @mock.patch('app.main.views.login.data_api_client')
     @mock.patch('app.main.views.login.send_email')
     def test_should_503_if_email_fails_to_send(self, send_email, data_api_client):
-        data_api_client.is_email_address_with_valid_buyer_domain.return_value = True
         send_email.side_effect = EmailError("Arrrgh")
         res = self.post_form()
         assert res.status_code == 503
@@ -667,7 +666,6 @@ class TestBuyersCreation(BaseApplicationTest):
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_show_error_page_for_unrecognised_email_domain(self, data_api_client):
-        data_api_client.is_email_address_with_valid_buyer_domain.return_value = False
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={
@@ -684,7 +682,6 @@ class TestBuyersCreation(BaseApplicationTest):
     @mock.patch('app.main.views.login.data_api_client')
     @mock.patch('app.main.views.login.send_email')
     def test_should_503_if_email_fails_to_send(self, send_email, data_api_client):
-        data_api_client.is_email_address_with_valid_buyer_domain.return_value = True
         send_email.side_effect = EmailError("Arrrgh")
         res = self.client.post(
             self.expand_path('/buyers/create'),

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -557,6 +557,7 @@ class TestBuyerInviteRequest(BaseApplicationTest):
 
         assert res.status_code == 400
         data = res.get_data(as_text=True)
+
         assert has_validation_errors(data, 'government_emp_checkbox')
 
     @mock.patch('app.main.views.login.data_api_client')
@@ -637,24 +638,6 @@ class TestBuyersCreation(BaseApplicationTest):
         assert res.status_code == 200
         assert 'Activate your account' in res.get_data(as_text=True)
 
-    @mock.patch('app.main.views.login.send_email')
-    @mock.patch('app.main.views.login.data_api_client')
-    def test_require_acknowledgement_of_requirements(self, data_api_client, send_email):
-        res = self.client.post(
-            self.expand_path('/buyers/create'),
-            data={
-                'email_address': 'valid@test.gov.au',
-                # government_emp_checkbox unchecked
-                'csrf_token': FakeCsrf.valid_token,
-            },
-            follow_redirects=True
-        )
-
-        assert res.status_code == 400
-        data = res.get_data(as_text=True)
-        print data
-        assert has_validation_errors(data, 'government_emp_checkbox')
-
     def test_should_raise_validation_error_for_invalid_email_address(self):
         res = self.client.post(
             self.expand_path('/buyers/create'),
@@ -688,7 +671,7 @@ class TestBuyersCreation(BaseApplicationTest):
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={
-                'email_address': 'valid@test.gov.uk',
+                'email_address': 'valid@example.com',
                 'government_emp_checkbox': 'checked',
                 'csrf_token': FakeCsrf.valid_token,
             },
@@ -706,7 +689,7 @@ class TestBuyersCreation(BaseApplicationTest):
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={
-                'email_address': 'valid@test.gov.uk',
+                'email_address': 'valid@test.gov.au',
                 'government_emp_checkbox': 'checked',
                 'csrf_token': FakeCsrf.valid_token,
             },
@@ -721,7 +704,7 @@ class TestBuyersCreation(BaseApplicationTest):
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={
-                'email_address': 'valid@test.gov.uk',
+                'email_address': 'valid@test.gov.au',
                 'government_emp_checkbox': 'checked',
                 'csrf_token': FakeCsrf.valid_token,
             },
@@ -729,7 +712,7 @@ class TestBuyersCreation(BaseApplicationTest):
         )
         assert res.status_code == 200
         data_api_client.create_audit_event.assert_called_with(audit_type=AuditTypes.invite_user,
-                                                              data={'invitedEmail': 'valid@test.gov.uk'})
+                                                              data={'invitedEmail': 'valid@test.gov.au'})
 
 
 class TestCreateUser(BaseApplicationTest):


### PR DESCRIPTION
* Properly check email domains and give appropriate error messages
* Stop asking for terms acknowledgement on creation page (because admins
  are using that now)