### PR TITLE
add brief builder link to homepage

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -47,7 +47,8 @@ def index():
     return render_template(
         'index.html',
         frameworks={framework['slug']: framework for framework in frameworks},
-        temporary_message=temporary_message
+        temporary_message=temporary_message,
+        brief_builder=current_app.config.get('FEATURE_FLAGS_BRIEF_BUILDER', False)
     )
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,7 +21,13 @@
       <article>
         <h3><a href="{{ url_for('.supplier_search') }}">Find an ICT supplier</a></h3>
         <p>Browse the Marketplace for approved digital service professionals.</p>
-        <p><a href="{{ url_for('.supplier_search') }}" role="button">View the catalogue</a></p>
+        <p>
+          <a href="{{ url_for('.supplier_search') }}" role="button">View the catalogue</a>
+         {% if brief_builder %}
+            Or
+            <a href="{{ url_for('.info_page_for_starting_a_brief', framework_slug='digital-service-professionals', lot_slug='digital-professionals') }}" role="button">Create a brief</a>
+        {% endif %}
+       </p>
       </article>
     </li>
     <li>

--- a/config.py
+++ b/config.py
@@ -74,6 +74,7 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
     FEATURE_FLAGS_HIDE_SUPPLIERS_NAME_SEARCH = enabled_since('2016-08-01')  # Change to False when it is ready
+    FEATURE_FLAGS_BRIEF_BUILDER = True
 
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'
@@ -123,6 +124,7 @@ class Live(Config):
     DEBUG = False
     DM_HTTP_PROTO = 'https'
     DM_GA_CODE = 'UA-72722909-5'
+    FEATURE_FLAGS_BRIEF_BUILDER = False
 
 
 class Preview(Live):


### PR DESCRIPTION
Put a link on the homepage but don't display on live

I am ignoring the flask feature-flags for now because I couldn't get them to work.

I don't think we need them anyway - we will want to change config value to put a feature live rather than rely on a date.