### PR TITLE
Point account creation links to buyer account invite request page

### DIFF
--- a/app/templates/auth/create-buyer-account.html
+++ b/app/templates/auth/create-buyer-account.html
@@ -29,7 +29,7 @@
 {% include "toolkit/page-heading.html" %}
 {% endwith %}
 
-<form method="POST" action="{{ url_for('.submit_create_buyer_account') }}">
+<form method="POST" action="{{ url_for('.submit_buyer_invite_request') }}">
   {{ form.csrf_token }}
 
   {%

--- a/app/templates/auth/create-buyer-user-error.html
+++ b/app/templates/auth/create-buyer-user-error.html
@@ -14,7 +14,7 @@
   </header>
   <p>
     The link you used to create an account may have expired.<br/>
-    Check you’ve entered the correct link or <a href="{{ url_for('.create_buyer_account') }}">request a new link</a>.<br/>
+    Check you’ve entered the correct link or <a href="{{ url_for('.buyer_invite_request') }}">request a new link</a>.<br/>
     If you still can’t create an account, email <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>
   </p>
 
@@ -44,7 +44,7 @@
       <h1>The details you provided are registered with a supplier.</h1>
     </header>
     <p>Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
-    <p>You can <a href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
+    <p>You can <a href="{{ url_for('.buyer_invite_request') }}">create a buyer account using a different email address</a>, or email
       <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a> to have your account
       converted to a buyer account.</p>
     <p>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -66,7 +66,7 @@
 {% endwith %}
 
 <p>
-    Don't have a buyer account? <a href="{{ url_for('.create_buyer_account') }}">Create one now</a>.
+    Don't have a buyer account? <a href="{{ url_for('.buyer_invite_request') }}">Create one now</a>.
   </p>
 
 <form action="{{ url_for('.process_login', next=next) }}" method="POST">

--- a/app/templates/emails/buyer_account_invite_request_email.html
+++ b/app/templates/emails/buyer_account_invite_request_email.html
@@ -21,7 +21,7 @@ We've received a request for a buyer account.
 	<dd>{{ form.justification.data }}</dd>
 </dl>
 
-Please review this request and, if accepted, <a href="{{ url_for('main.create_buyer_account', _external=True) }}">create the account</a>.
+Please review this request and, if accepted, <a href="{{ url_for('main.buyer_invite_request', _external=True) }}">create the account</a>.
 
 </body>
 </html>

--- a/app/templates/main_template.html
+++ b/app/templates/main_template.html
@@ -66,7 +66,7 @@
         <div class="feedback">
           <ul class="inline-links--inverted">
             {% if not current_user.is_authenticated %}
-            <li><a href="{{ url_for('main.create_buyer_account') }}">Sign up</a></li>
+            <li><a href="{{ url_for('main.buyer_invite_request') }}">Sign up</a></li>
             <li><a href="{{ url_for('main.render_login') }}">Log in</a></li>
             {% else %}
             <li><a href="{{ url_for('main.logout') }}">Log out</a></li>


### PR DESCRIPTION
We currently don't have a page for supplier account creation, so I
expect we'll create a new, general account creation landing page in the future.
That's why I haven't bothered updating the URLs to make this the
creation page.