### PR TITLE
Add a reverse proxy config for dev purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ python application.py runserver
 
 The buyer app runs on port 5002 by default. Use the app at [http://127.0.0.1:5002/](http://127.0.0.1:5002/)
 
+If you want to run the other frontends in a local environment, there's a reverse proxy config that unifies them behind one domain.
+To use it you need to install lighttpd on your system, then you can run
+
+```
+./scripts/reverse_proxy.sh
+```
+
+Run the other frontends using the normal `python application.py runserver` commands in other terminals.
+The Marketplace should now be available at `http://localhost:8000/marketplace/`
+
 ### Using FeatureFlags
 
 To use feature flags, check out the documentation in (the README of)

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -1,0 +1,22 @@
+# lighttpd config for reverse proxying the various marketplace pieces together behind one domain
+
+# Not used, but required by lighttpd
+server.document-root = "/does-not-exist"
+
+server.bind = "localhost"
+server.port = 8000
+
+server.modules = (
+	"mod_proxy",
+)
+
+proxy.server = (
+	"/marketplace/suppliers" => ((
+		"host" => "127.0.0.1",
+		"port" => 5003
+	)),
+	"/marketplace" => ((
+		"host" => "127.0.0.1",
+		"port" => 5002
+	)),
+)

--- a/scripts/reverse_proxy.sh
+++ b/scripts/reverse_proxy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+: ${LIGHTTPD=/usr/sbin/lighttpd}
+
+CONF=lighttpd.conf
+
+echo "Serving on"
+fgrep server.bind "$CONF"
+fgrep server.port "$CONF"
+echo
+
+"$LIGHTTPD" -D -f "$CONF"


### PR DESCRIPTION
The application is split into the buyer, supplier and admin frontends.
This simple reverse proxy can be run as a non-root user to put all the
apps behind one domain so that they integrate.

Currently only the supplier and buyer frontends are configured to work
behind this proxy.