### PR TITLE
Re-enable the original buyer account creation process

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -239,13 +239,8 @@ def submit_buyer_invite_request():
     return render_template('auth/buyer-invite-request-complete.html')
 
 
-# FIXME: buyer creation should be in the admin site so that it's not even accessible from the frontend
-
-
 @main.route('/buyers/create', methods=["GET"])
 def create_buyer_account():
-    if not current_user.is_authenticated or current_user.role != 'admin':
-        return current_app.login_manager.unauthorized()
     form = BuyerSignupEmailForm()
 
     return render_template_with_csrf("auth/create-buyer-account.html", form=form)
@@ -253,8 +248,6 @@ def create_buyer_account():
 
 @main.route('/buyers/create', methods=['POST'])
 def submit_create_buyer_account():
-    if not current_user.is_authenticated or current_user.role != 'admin':
-        return current_app.login_manager.unauthorized()
     current_app.logger.info(
         "buyercreate: post create-buyer-account")
     form = BuyerSignupEmailForm(request.form)

--- a/app/templates/auth/create-buyer-user-error.html
+++ b/app/templates/auth/create-buyer-user-error.html
@@ -14,7 +14,7 @@
   </header>
   <p>
     The link you used to create an account may have expired.<br/>
-    Check you’ve entered the correct link or <a href="{{ url_for('.buyer_invite_request') }}">request a new link</a>.<br/>
+    Check you’ve entered the correct link or <a href="{{ url_for('.create_buyer_account') }}">request a new link</a>.<br/>
     If you still can’t create an account, email <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>
   </p>
 
@@ -44,7 +44,7 @@
       <h1>The details you provided are registered with a supplier.</h1>
     </header>
     <p>Your email address is already registered as an account with ‘{{ user.supplier_name }}’.</p>
-    <p>You can <a href="{{ url_for('.buyer_invite_request') }}">create a buyer account using a different email address</a>, or email
+    <p>You can <a href="{{ url_for('.create_buyer_account') }}">create a buyer account using a different email address</a>, or email
       <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a> to have your account
       converted to a buyer account.</p>
     <p>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -66,7 +66,7 @@
 {% endwith %}
 
 <p>
-    Don't have a buyer account? <a href="{{ url_for('.buyer_invite_request') }}">Create one now</a>.
+    Don't have a buyer account? <a href="{{ url_for('.create_buyer_account') }}">Create one now</a>.
   </p>
 
 <form action="{{ url_for('.process_login', next=next) }}" method="POST">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -45,7 +45,7 @@
       <article>
         <h2>Getting started</h2>
         <ul class="list-small">
-          <li><a href="{{ url_for('.buyer_invite_request') }}">Register as a buyer</a></li>
+          <li><a href="{{ url_for('.create_buyer_account') }}">Register as a buyer</a></li>
           <li><a href="{{ url_for('.new_seller') }}">Become an ICT supplier</a></li>
           <li><a href="{{ url_for('.buyers_guide') }}">Buyer's guide</a></li>
         </ul>

--- a/app/templates/main_template.html
+++ b/app/templates/main_template.html
@@ -64,7 +64,7 @@
         <div class="feedback">
           <ul class="inline-links--inverted">
             {% if not current_user.is_authenticated %}
-            <li><a href="{{ url_for('main.buyer_invite_request') }}">Sign up</a></li>
+            <li><a href="{{ url_for('main.create_buyer_account') }}">Sign up</a></li>
             <li><a href="{{ url_for('main.render_login') }}">Log in</a></li>
             {% else %}
             <li><a href="{{ url_for('main.logout') }}">Log out</a></li>

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -608,18 +608,8 @@ class TestBuyerInviteRequest(BaseApplicationTest):
 
 
 class TestBuyersCreation(BaseApplicationTest):
-    def test_require_admin_to_view_form(self):
-        # not logged in as admin
-        res = self.client.get(self.expand_path('/buyers/create'))
-        assert res.status_code == 302
-
-    def test_require_admin_to_submit_form(self):
-        # not logged in as admin
-        res = self.client.post(self.expand_path('/buyers/create'))
-        assert res.status_code == 302
 
     def test_should_get_create_buyer_form_ok(self):
-        self.login_as_admin()
         res = self.client.get(self.expand_path('/buyers/create'))
         assert res.status_code == 200
         assert 'Create a buyer account' in res.get_data(as_text=True)
@@ -628,7 +618,6 @@ class TestBuyersCreation(BaseApplicationTest):
     @mock.patch('app.main.views.login.send_email')
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_be_able_to_submit_valid_email_address(self, data_api_client, send_email):
-        self.login_as_admin()
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={
@@ -642,7 +631,6 @@ class TestBuyersCreation(BaseApplicationTest):
         assert 'Activate your account' in res.get_data(as_text=True)
 
     def test_should_raise_validation_error_for_invalid_email_address(self):
-        self.login_as_admin()
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={
@@ -659,7 +647,6 @@ class TestBuyersCreation(BaseApplicationTest):
         assert has_validation_errors(data, 'email_address')
 
     def test_should_raise_validation_error_for_empty_email_address(self):
-        self.login_as_admin()
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={'csrf_token': FakeCsrf.valid_token},
@@ -672,7 +659,6 @@ class TestBuyersCreation(BaseApplicationTest):
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_show_error_page_for_unrecognised_email_domain(self, data_api_client):
-        self.login_as_admin()
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={
@@ -689,7 +675,6 @@ class TestBuyersCreation(BaseApplicationTest):
     @mock.patch('app.main.views.login.data_api_client')
     @mock.patch('app.main.views.login.send_email')
     def test_should_503_if_email_fails_to_send(self, send_email, data_api_client):
-        self.login_as_admin()
         send_email.side_effect = EmailError("Arrrgh")
         res = self.client.post(
             self.expand_path('/buyers/create'),
@@ -706,7 +691,6 @@ class TestBuyersCreation(BaseApplicationTest):
     @mock.patch('app.main.views.login.send_email')
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_create_audit_event_when_email_sent(self, data_api_client, send_email):
-        self.login_as_admin()
         res = self.client.post(
             self.expand_path('/buyers/create'),
             data={


### PR DESCRIPTION
The alternative process is being redesigned. Until that's done, buyer
account creation needs to be opened up again.