### PR TITLE
Publish brief

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -398,11 +398,6 @@ def publish_brief(framework_slug, lot_slug, brief_id):
             url_for('.view_brief_overview', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],
                     brief_id=brief['id'], published='true'))
     else:
-        #  requirements length is a required question but is handled separately to other
-        #  required questions on the publish page if it's unanswered.
-        if sections.get_section('set-how-long-your-requirements-will-be-open-for') and \
-                sections.get_section('set-how-long-your-requirements-will-be-open-for').questions[0].answer_required:
-                unanswered_required -= 1
 
         email_address = brief_users['emailAddress']
         dates = get_publishing_dates(brief)

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1296,52 +1296,6 @@ class TestPublishBrief(BaseApplicationTest):
         assert 'Your requirements will be open for 1 week' not in page_html
         assert not document.xpath('//a[contains(text(), "Set how long your requirements will be live for")]')
 
-    def test_heading_for_unanswered_questions_not_displayed_if_only_requirements_length_unset(self, data_api_client):
-        self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug='digital-outcomes-and-specialists',
-            status='live',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True)
-            ]
-        )
-
-        brief_json = api_stubs.brief(status="draft")
-        brief_questions = brief_json['briefs']
-        brief_questions.update({
-            'backgroundInformation': 'test background info',
-            'contractLength': 'A very long time',
-            'culturalFitCriteria': ['CULTURAL', 'FIT'],
-            'culturalWeighting': 10,
-            'essentialRequirements': 'Everything',
-            'evaluationType': ['test evaluation type'],
-            'existingTeam': 'team team team',
-            'importantDates': 'Near future',
-            'location': 'somewhere',
-            'numberOfSuppliers': 3,
-            'organisation': 'test organisation',
-            'priceWeighting': 80,
-            'specialistRole': 'communicationsManager',
-            'specialistWork': 'work work work',
-            'startDate': 'startDate',
-            'summary': 'blah',
-            'technicalWeighting': 10,
-            'workingArrangements': 'arrangements',
-            'workplaceAddress': 'address'
-        })
-        data_api_client.get_brief.return_value = brief_json
-
-        res = self.client.get(self.expand_path(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
-            "digital-specialists/1234/publish"
-        ))
-        page_html = res.get_data(as_text=True)
-        document = html.fromstring(page_html)
-
-        assert res.status_code == 200
-        assert "You still need to complete the following questions before your requirements " \
-               "can be published:" not in page_html
-
 
 @mock.patch('app.buyers.views.buyers.data_api_client')
 class TestDeleteBriefSubmission(BaseApplicationTest):


### PR DESCRIPTION
As the requirementLength was excluded from the unanswered_required, frontend did not know about the missing required field and allowed to be published. But the API raised validation error as the required field wasn't filled. Here is the snippet from the brief_publish_confirmation.html template.
```
{% if not published and unanswered_required > 0 %}
      <div class="dmspeak">
        <p><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
      </div>
      {% for section in sections %}
        {% for question in section.questions %}
          {% if question.answer_required %}
            <ul>
              <li>
                <a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question or question.name }}</a>
              </li>
            </ul>
          {% endif %}
        {% endfor %}
      {% endfor %}
...
...
{% endif %}
```