### PR TITLE
Init bdd integration tests

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -12,3 +12,6 @@ watchdog==0.8.3
 coverage==3.7.1
 pytest-cov==2.2.0
 python-coveralls==2.5.0
+
+pytest-bdd==2.17.1
+pytest-splinter==1.7.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ exclude = ./venv,./bower_components,./node_modules,./app/content
 max-line-length = 120
 
 [pytest]
-norecursedirs = venv app/content bower_components node_modules
+norecursedirs = venv app/content bower_components node_modules tests/integration

--- a/tests/integration/catalogue.feature
+++ b/tests/integration/catalogue.feature
@@ -1,0 +1,7 @@
+Feature: Supplier Catalogue
+    Buyers can search and view Suppliers.
+
+Scenario: Navigate to search page
+    Given I am on the home page
+    When I click the Browse sellers link
+    Then I should see the Suppliers search – Digital Marketplace page

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+import os
+
+
+@pytest.fixture(scope='session')
+def splinter_webdriver():
+    return 'phantomjs'
+
+
+config = {'dm_frontend_url': os.getenv('DM_FRONTEND_URL', 'http://localhost:5002/marketplace')}

--- a/tests/integration/test_catalogue.py
+++ b/tests/integration/test_catalogue.py
@@ -1,0 +1,23 @@
+from pytest_bdd import scenario, given, when, then, parsers
+from conftest import config
+
+
+@scenario('catalogue.feature', 'Navigate to search page')
+def test_catalogue():
+    pass
+
+
+@given("I am on the home page")
+def home_page(browser):
+    print config
+    browser.visit(config['dm_frontend_url'])
+
+
+@when(parsers.parse('I click the {link_text} link'))
+def click_link(link_text, browser):
+    browser.click_link_by_text(link_text)
+
+
+@then(parsers.parse('I should see the {title} page'))
+def page_verify(title, browser):
+    assert browser.title == title


### PR DESCRIPTION
Rather then inheriting all the ruby tests from the uk, most of which are broken and need to be re-written, I thought it was an opportunity to take a fresh approach with a Python-based bdd framework.  After assessing a few, https://github.com/pytest-dev/pytest-bdd looks the most promising:

- built off py.test which we are all familiar with
- makes use of py.test fixtures
- integrates well with our unit tests
- integrates with splinter project via https://github.com/pytest-dev/pytest-splinter

For now I've disabled the ./tests/integration folder in py.test config.  Need to figure out best way to run these tests in relation to release cycle.