### PR TITLE
Allow the site to serve from / instead of /marketplace

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from flask_login import LoginManager
 
@@ -19,7 +21,8 @@ content_loader.load_manifest('digital-service-professionals', 'briefs', 'display
 
 
 def create_app(config_name):
-    application = Flask(__name__, static_url_path=configs[config_name].ASSET_PATH)
+    asset_path = os.environ.get('ASSET_PATH', configs[config_name].ASSET_PATH)
+    application = Flask(__name__, static_url_path=asset_path)
 
     init_app(
         application,

--- a/app/helpers/login_helpers.py
+++ b/app/helpers/login_helpers.py
@@ -10,6 +10,8 @@ from dmutils.email import (
 
 def redirect_logged_in_user(next_url=None):
     site_url_prefix = current_app.config['URL_PREFIX']
+    if not site_url_prefix:
+        site_url_prefix = '/'
     if current_user.is_authenticated:
         if next_url and next_url.startswith(site_url_prefix):
             return redirect(next_url)

--- a/config.py
+++ b/config.py
@@ -2,17 +2,8 @@ import os
 import hashlib
 import jinja2
 from dmutils.status import enabled_since, get_version_label
-from dmutils.asset_fingerprint import AssetFingerprinter
 
 basedir = os.path.abspath(os.path.dirname(__file__))
-
-
-def get_asset_fingerprint(asset_file_path):
-    hasher = hashlib.md5()
-    with open(asset_file_path, 'rb') as asset_file:
-        buf = asset_file.read()
-        hasher.update(buf)
-    return hasher.hexdigest()
 
 
 class Config(object):
@@ -69,11 +60,6 @@ class Config(object):
     BUYER_CREATION_TOKEN_SALT = 'BuyerCreation'
 
     ASSET_PATH = URL_PREFIX + '/static'
-    BASE_TEMPLATE_DATA = {
-        'header_class': 'with-proposition',
-        'asset_path': ASSET_PATH + '/',
-        'asset_fingerprinter': AssetFingerprinter(asset_root=ASSET_PATH + '/')
-    }
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 Werkzeug==0.11.10
 
-git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@25.3.0#egg=dto-digitalmarketplace-utils==25.3.0
+git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@25.4.0#egg=dto-digitalmarketplace-utils==25.4.0
 git+https://github.com/AusDTO/digitalmarketplace-content-loader.git@1.1.1#egg=digitalmarketplace-content-loader==1.1.1
 git+https://github.com/AusDTO/digitalmarketplace-apiclient.git@6.0.0#egg=digitalmarketplace-apiclient==6.0.0
 

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -393,7 +393,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         )
 
         breadcrumbs_we_expect = [
-            ('Home', '/marketplace/'),
+            ('Home', self.expand_path('/')),
             ('Dashboard', self.expand_path('/buyers')),
             ('Brief Overview',
              self.expand_path(


### PR DESCRIPTION
CSS and other static files are being served from /marketplace.  This is
because the CSS is built once in CI, so it isn't simple to have
different paths.  The CSS contains references to icons.