### PR TITLE
Cache the roles on the search page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 from flask import Flask
+from flask_cache import Cache
 from flask_login import LoginManager
 
 import dmapiclient
@@ -9,6 +10,7 @@ from dmcontent.content_loader import ContentLoader
 
 from config import configs
 
+cache = Cache()
 login_manager = LoginManager()
 data_api_client = dmapiclient.DataAPIClient()
 feature_flags = flask_featureflags.FeatureFlag()
@@ -30,6 +32,7 @@ def create_app(config_name):
         data_api_client=data_api_client,
         feature_flags=feature_flags,
         login_manager=login_manager,
+        cache=cache,
     )
 
     from .main import main as main_blueprint

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -8,7 +8,7 @@ from app.api_client.data import DataAPIClient
 from app.main.utils import get_page_list
 
 from ...main import main
-from app import content_loader
+from app import cache
 
 
 # For prototyping
@@ -28,6 +28,7 @@ def normalise_role(role_name):
     return role_name.replace('Senior ', '').replace('Junior ', '')  # Mind the white space after Junior
 
 
+@cache.cached(timeout=300, key_prefix='get_all_roles')
 def get_all_roles(data_api_client):
     """
     Returns a two-valued tuple:
@@ -36,8 +37,6 @@ def get_all_roles(data_api_client):
 
     The original role data is actually a list of dicts because of folding Senior/Junior roles into one role.
     """
-    # TODO: cache this function
-
     response = data_api_client.get_roles()
 
     roles = set()
@@ -45,8 +44,7 @@ def get_all_roles(data_api_client):
     for role_data in response['roles']:
         role = normalise_role(role_data['role'])
         raw_role_data[role].append(role_data)
-        if role not in roles:
-            roles.add(role)
+        roles.add(role)
     return roles, raw_role_data
 
 

--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ class Config(object):
     DM_HTTP_PROTO = 'http'
     DM_DEFAULT_CACHE_MAX_AGE = 24*3600
     DM_SEND_EMAIL_TO_STDERR = False
+    DM_CACHE_TYPE = 'dev'
 
     # matches api(s)
     DM_SEARCH_PAGE_SIZE = 100
@@ -114,6 +115,7 @@ class Live(Config):
     DEBUG = False
     DM_HTTP_PROTO = 'https'
     DM_GA_CODE = 'UA-72722909-5'
+    DM_CACHE_TYPE = 'prod'
 
 
 class Preview(Live):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 Werkzeug==0.11.10
 
-git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@25.5.0#egg=dto-digitalmarketplace-utils==25.5.0
+git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@25.6.0#egg=dto-digitalmarketplace-utils==25.6.0
 git+https://github.com/AusDTO/digitalmarketplace-content-loader.git@1.1.1#egg=digitalmarketplace-content-loader==1.1.1
 git+https://github.com/AusDTO/digitalmarketplace-apiclient.git@6.0.0#egg=digitalmarketplace-apiclient==6.0.0
 


### PR DESCRIPTION
This means we don't hit the database on every page render, which
increases our capacity to serve this page multiple times.