### PR TITLE
separate the monitoring build steps

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,9 +35,13 @@ deployment:
   production:
     tag: /release-.*/
     commands:
-      - DOCKERFILE_PATH=./monitoring/Dockerfile DOCKER_IMAGE_NAME=gov-au-marketplace ./scripts/ci-monitor-build.sh
       - cf login -a https://api.system.platform.digital.gov.au -o dto -u $CF_USER_PROD -p $CF_PASSWORD_PROD
       - cf target -o dto -s digital-marketplace
       - APP=dm-buyer-green ./scripts/cf_ha_deploy.sh
       - APP=dm-buyer-blue ./scripts/cf_ha_deploy.sh
+
+  monitoring:
+    tag: /monitor-.*/
+    commands:
+      - DOCKERFILE_PATH=./monitoring/Dockerfile DOCKER_IMAGE_NAME=gov-au-marketplace ./scripts/ci-monitor-build.sh
       - DOCKER_COMPOSE_FILE_PATH=./monitoring/docker-compose-ecs.yml DOCKER_IMAGE_NAME=gov-au-marketplace DOCKER_CONTAINER_NAME=gov-au-marketplace ./scripts/ci-monitor-deploy.sh


### PR DESCRIPTION
I confirmed with Michael that the Sensu stuff does not need to be run on every live deploy - only when the monitoring config changes

This is a bit of a kludge but will at least speed up the live builds.