### PR TITLE
add pdf download to brief page

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from flask_login import current_user
-from flask import abort, current_app, make_response, render_template, request
+from flask import abort, current_app, make_response, render_template, request, url_for
 
 from dmapiclient import APIError
 from dmcontent.content_loader import ContentNotFoundError
@@ -14,6 +14,7 @@ from ...helpers.shared_helpers import get_one_framework_by_status_in_order_of_pr
 from ..forms.brief_forms import BriefSearchForm
 
 from app import data_api_client, content_loader
+from flask_weasyprint import HTML, render_pdf
 
 
 @main.route('/')
@@ -145,7 +146,13 @@ def get_brief_by_id(framework_slug, brief_id):
         brief=brief,
         brief_responses=brief_responses,
         content=brief_content,
+        show_pdf_link=current_app.config.get('FEATURE_FLAGS_BRIEF_PDF', False)
     )
+
+
+@main.route('/<framework_slug>/opportunities/brief_<brief_id>.pdf')
+def get_brief_pdf(framework_slug, brief_id):
+    return render_pdf(url_for('.get_brief_by_id', framework_slug=framework_slug, brief_id=brief_id))
 
 
 @main.route('/<framework_slug>/opportunities')

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -146,11 +146,11 @@ def get_brief_by_id(framework_slug, brief_id):
         brief=brief,
         brief_responses=brief_responses,
         content=brief_content,
-        show_pdf_link=current_app.config.get('FEATURE_FLAGS_BRIEF_PDF', False)
+        show_pdf_link=brief['status'] in ['live', 'closed'] and current_app.config.get('FEATURE_FLAGS_BRIEF_PDF', False)
     )
 
 
-@main.route('/<framework_slug>/opportunities/brief_<brief_id>.pdf')
+@main.route('/<framework_slug>/opportunities/opportunity_<brief_id>.pdf')
 def get_brief_pdf(framework_slug, brief_id):
     return render_pdf(url_for('.get_brief_by_id', framework_slug=framework_slug, brief_id=brief_id))
 

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -96,4 +96,11 @@
   {% endif %}
   {% endif %}
 
+{% if show_pdf_link %}
+  <div class="grid-row">
+    <a href="{{ url_for('.get_brief_pdf', framework_slug=brief.frameworkSlug, brief_id=brief.id) }}">
+        Download as pdf
+    </a>
+  </div>
+{% endif %}
 {% endblock %}

--- a/config.py
+++ b/config.py
@@ -73,6 +73,7 @@ class Config(object):
     FEATURE_FLAGS_HIDE_SUPPLIERS_NAME_SEARCH = enabled_since('2016-08-01')  # Change to False when it is ready
     FEATURE_FLAGS_BRIEF_BUILDER = True
     FEATURE_FLAGS_BRIEF_FILTER = True
+    FEATURE_FLAGS_BRIEF_PDF = True
 
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'
@@ -124,6 +125,7 @@ class Live(Config):
     DM_GA_CODE = 'UA-72722909-5'
     DM_CACHE_TYPE = 'prod'
     FEATURE_FLAGS_BRIEF_FILTER = False
+    FEATURE_FLAGS_BRIEF_PDF = False
 
 
 class Preview(Live):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ git+https://github.com/AusDTO/digitalmarketplace-content-loader.git@1.1.1#egg=di
 git+https://github.com/AusDTO/digitalmarketplace-apiclient.git@6.0.0#egg=digitalmarketplace-apiclient==6.0.0
 
 newrelic==2.68.0.50
+Flask-WeasyPrint==0.5

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -102,7 +102,7 @@ class TestBriefPage(BaseApplicationTest):
 
     def test_dos_brief_pdf(self):
         brief_id = self.brief['briefs']['id']
-        res = self.client.get(self.expand_path('/digital-service-professionals/opportunities/brief_{}.pdf')
+        res = self.client.get(self.expand_path('/digital-service-professionals/opportunities/opportunity_{}.pdf')
                               .format(brief_id))
         assert_equal(200, res.status_code)
         assert_equal(res.mimetype, 'application/pdf')

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -100,6 +100,13 @@ class TestBriefPage(BaseApplicationTest):
 
         self._assert_page_title(document)
 
+    def test_dos_brief_pdf(self):
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get(self.expand_path('/digital-service-professionals/opportunities/brief_{}.pdf')
+                              .format(brief_id))
+        assert_equal(200, res.status_code)
+        assert_equal(res.mimetype, 'application/pdf')
+
     @pytest.mark.skipif(True, reason="test failing on AU CI server")
     def test_dos_brief_has_important_dates(self):
         brief_id = self.brief['briefs']['id']


### PR DESCRIPTION
Found https://pythonhosted.org/Flask-WeasyPrint that does not make network call for relative urls.

Featured-flagged the link for now.