### PR TITLE
send slack notification on prod build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,3 +41,4 @@ deployment:
       - APP=dm-buyer-green ./scripts/cf_ha_deploy.sh
       - APP=dm-buyer-blue ./scripts/cf_ha_deploy.sh
       - DOCKER_COMPOSE_FILE_PATH=./monitoring/docker-compose-ecs.yml DOCKER_IMAGE_NAME=gov-au-marketplace DOCKER_CONTAINER_NAME=gov-au-marketplace ./scripts/ci-monitor-deploy.sh
+      - ./scripts/ci-notify.sh

--- a/scripts/ci-notify.sh
+++ b/scripts/ci-notify.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -g -X POST --data-urlencode 'payload={"channel": "#marketplace", "username": "releasebot", "text": "Some code went live! '"$CIRCLE_REPOSITORY_URL"'/releases/tag/'"$CIRCLE_TAG"'", "icon_emoji": ":lightning:"}' "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Simple script that sends notification for live builds only

Couldn't find anything out-of-the-box that just did notifications on github release eg. the github slack app sends notifications for tags + branches which would be too noisy