### PR TITLE
Tweak copy for buyer account registration

### DIFF
--- a/app/templates/auth/buyer-invite-request.html
+++ b/app/templates/auth/buyer-invite-request.html
@@ -24,9 +24,6 @@
 <div>
   <h2>You and your manager need a government email address</h2>
   <p>
-    Email addresses must end with <strong>.gov.au</strong>.
-  </p>
-  <p>
     If you believe your email address should be recognised email
     <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>.
   </p>
@@ -69,7 +66,7 @@
   {%
     with
       question = "Line manager's email address",
-      hint = 'Your line manager\'s email address must end in <strong>.gov.au</strong>.'|safe,
+      hint = 'Your line manager\'s email address must be a government email address.'|safe,
       name = "manager_email",
       value = form.manager_email.data,
       error = form.manager_email.errors[0]

--- a/app/templates/auth/buyer-signup.html
+++ b/app/templates/auth/buyer-signup.html
@@ -52,8 +52,9 @@
 
   {%
     with
-      question = "Your name",
+      question = "Your full name",
       name = "name",
+      hint = "",
       value = form.name.data,
       error = form.name.errors[0]
   %}
@@ -62,9 +63,9 @@
 
   {%
     with
-      question = "Your email address",
-      hint = 'You must have an email address ending in <strong>.gov.au</strong>.'|safe,
+      question = "Your government email address",
       name = "email_address",
+      hint = "",
       value = form.email_address.data,
       error = form.email_address.errors[0]
   %}


### PR DESCRIPTION
The government email address domain whitelist is no longer restricted to
.gov.au