### PR TITLE
Hide non-used sections of seller details

### DIFF
--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -121,13 +121,13 @@
     {% endfor %}
   </li>
   {% endif %}
-  <li>
+  <li class="hidden">
     <p>Endorsements</p>
     <article>
       To be added
     </article>
   </li>
-  <li>
+  <li class="hidden">
     <p>Case studies</p>
     <article>
       To be added


### PR DESCRIPTION
Hide endorsements and case studies of seller details - not being used yet.