### PR TITLE
Add corresponding CSS to preserve whitespace in templates

### DIFF
--- a/app/assets/scss/_tables.scss
+++ b/app/assets/scss/_tables.scss
@@ -89,4 +89,10 @@ table.content-table {
       border-bottom: 0;
     }
   }
+
+  .summary-item-free-text {
+    span {
+      white-space: pre-wrap;
+    }
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/ausdto/dto-digitalmarketplace-frontend-toolkit.git#v18.2.2",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/ausdto/dto-digitalmarketplace-frontend-toolkit.git#v18.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/ausdto/dto-digitalmarketplace-frameworks.git#v2.7.0"
   }


### PR DESCRIPTION
Adding `pre-wrap` to the textarea fields. pre-wrap preserves new lines, spaces and tabs while wrapping text.