### PR TITLE
Stop staging downtime on push

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,17 +29,14 @@ deployment:
     branch: master
     commands:
       - cf login -a https://api.system.staging.digital.gov.au -o dto -u $CF_USER_STAGING -p $CF_PASSWORD_STAGING
-      - cf target -o dto -s digital-marketplace
-      - cf push -f service.gov.au-manifest.staging.yml
+      - APP_GROUP=dm-dev-buyer HOSTNAME=dm-dev DOMAIN=apps.staging.digital.gov.au MANIFEST=service.gov.au-manifest.staging.yml ./scripts/cf_deploy_all.sh
       - py.test ./tests/integration
 
   production:
     tag: /release-.*/
     commands:
       - cf login -a https://api.system.platform.digital.gov.au -o dto -u $CF_USER_PROD -p $CF_PASSWORD_PROD
-      - cf target -o dto -s digital-marketplace
-      - APP=dm-buyer-green ./scripts/cf_ha_deploy.sh
-      - APP=dm-buyer-blue ./scripts/cf_ha_deploy.sh
+      - APP_GROUP=dm-buyer HOSTNAME=marketplace DOMAIN=service.gov.au MANIFEST=service.gov.au-manifest.production.yml ./scripts/cf_deploy_all.sh
       - ./scripts/ci-notify.sh
 
   monitoring:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ git+https://github.com/AusDTO/dto-digitalmarketplace-content-loader.git@1.5.1#eg
 git+https://github.com/AusDTO/dto-digitalmarketplace-apiclient.git@6.5.1#egg=dto-digitalmarketplace-apiclient==6.5.1
 
 newrelic==2.68.0.50
+cffi==1.5.2
 Flask-WeasyPrint==0.5

--- a/scripts/cf_deploy_all.sh
+++ b/scripts/cf_deploy_all.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -ex
+
+cf target -o dto -s digital-marketplace
+APP=${APP_GROUP}-green ./scripts/cf_ha_deploy.sh
+APP=${APP_GROUP}-blue ./scripts/cf_ha_deploy.sh

--- a/scripts/cf_ha_deploy.sh
+++ b/scripts/cf_ha_deploy.sh
@@ -2,6 +2,6 @@
 
 set -ex
 
-cf unmap-route "$APP" service.gov.au --hostname marketplace
-cf push "$APP" -f service.gov.au-manifest.production.yml
-cf map-route "$APP" service.gov.au --hostname marketplace
+cf unmap-route "$APP" "$DOMAIN" --hostname "$HOSTNAME"
+cf push "$APP" -f "$MANIFEST"
+cf map-route "$APP" "$DOMAIN" --hostname "$HOSTNAME"


### PR DESCRIPTION
The cffi library seems to be needed for new pushes to work properly.
Pushes to existing apps seem to have worked because the containers
already had the library installed from earlier versions of the
application.