### PR TITLE
Use explicit total briefs count on homepage dashboard

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -27,9 +27,7 @@ def index():
 
         suppliers_count = data_api_client.get_suppliers_count()['suppliers']['total']
 
-        briefs_count_json = data_api_client.get_briefs_count()
-        briefs_count = briefs_count_json['briefs']['open_to_all'] + briefs_count_json['briefs']['open_to_one'] + \
-            briefs_count_json['briefs']['open_to_selected']
+        briefs_count = data_api_client.get_briefs_count()['briefs']['total']
     except Exception as e:
         buyers_count = 0
         suppliers_count = 0

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -68,6 +68,7 @@ class TestHomepageBrowseList(BaseApplicationTest):
 
         data_api_client.get_briefs_count.return_value = {
             "briefs": {
+                "total": 8,
                 "open_to_all": 7,
                 "open_to_one": 0,
                 "open_to_selected": 1,


### PR DESCRIPTION
Dependent on https://github.com/AusDTO/dto-digitalmarketplace-api/pull/64

Briefs were being split (and recombined in the frontend) based on who they are open to. This is not required and could omit some that were made before this data was added.