### PR TITLE
Make the new update terms review feature live

### DIFF
--- a/config.py
+++ b/config.py
@@ -129,7 +129,7 @@ class Live(Config):
     # List all your feature flags below
     FEATURE_FLAGS = {
         'BRIEF_FILTER': False,
-        'ENFORCE_TERMS_REVIEW': False,
+        'ENFORCE_TERMS_REVIEW': True,
     }
 
 


### PR DESCRIPTION
We can't remove the feature flag completely until it's removed from
utils.