### PR TITLE
Use 'human' sort for opportunities listing

### DIFF
--- a/app/main/forms/brief_forms.py
+++ b/app/main/forms/brief_forms.py
@@ -45,7 +45,8 @@ class BriefSearchForm(DmForm):
             status=",".join(statuses),
             lot=",".join(lots),
             framework=self._framework_slug,
-            page=self.page.data
+            page=self.page.data,
+            human=True
         )
 
     def get_filters(self):

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -384,6 +384,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert regular_args == {
             "framework": "digital-service-professionals",
             "page": 1,
+            "human": True
         }
         assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {"live", "closed"}
         assert set(self._data_api_client.find_briefs.call_args[1]["lot"].split(",")) == {
@@ -419,6 +420,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert regular_args == {
             "framework": "digital-service-professionals",
             "page": 2,
+            "human": True
         }
         assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {"live"}
         assert set(self._data_api_client.find_briefs.call_args[1]["lot"].split(",")) == {"lot-one", "lot-three"}
@@ -479,6 +481,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert regular_args == {
             "framework": "digital-service-professionals",
             "page": 2,
+            "human": True
         }
         assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {"live", "closed"}
         assert set(self._data_api_client.find_briefs.call_args[1]["lot"].split(",")) == {


### PR DESCRIPTION
This ensures the sorting is open by published date then closed by published date so the first page has all the open opportunities (Brief.query.order_by(Brief.status.desc(), Brief.published_at.desc()))