### PR TITLE
On Opportunity page: change table layout to definitions lists (for accessibility)

### DIFF
--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -1,19 +1,23 @@
 {% import "toolkit/summary-table.html" as summary %}
 {% if brief.status != 'draft' %}
-{% call(item) summary.list_table(
-  [
-    {"label": "Published", "value": brief.publishedAt|dateformat},
-    {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsClosedAt|datetimeformat if brief.clarificationQuestionsClosedAt is defined},
-    {"label": "Closing date for applications", "value": brief.applicationsClosedAt|datetimeformat if brief.applicationsClosedAt is defined}
-  ],
-  caption="Important dates"
-) %}
-
-  {% call summary.row() %}
-    {{ summary.field_name(item.label) }}
-    {{ summary.text(item.value) }}
-  {% endcall %}
-{% endcall %}
+<table class="content-table summary-item-body">
+  <caption class="visuallyhidden">Important dates</caption>
+  <thead class="summary-item-field-headings-visible">
+    <tr></tr>
+  </thead>
+  <tbody>
+    {% for item in [
+      {"label": "Published", "value": brief.publishedAt|dateformat},
+      {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsClosedAt|datetimeformat if brief.clarificationQuestionsClosedAt is defined},
+      {"label": "Closing date for applications", "value": brief.applicationsClosedAt|datetimeformat if brief.applicationsClosedAt is defined}
+    ] %}
+      <tr class="summary-item-row">
+        <td class="summary-item-field-first"><span>{{ item.label }}</span></td>
+        <td class="summary-item-field summary-item-free-text"><span>{{ item.value }}</span></td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endif %}
 {% for section in content.summary(brief) %}
     {{ summary.heading(section.name, id="opportunity-attributes-{}".format(loop.index)) }}

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -1,23 +1,14 @@
 {% import "toolkit/summary-table.html" as summary %}
 {% if brief.status != 'draft' %}
-<table class="content-table summary-item-body">
-  <caption class="visuallyhidden">Important dates</caption>
-  <thead class="summary-item-field-headings-visible">
-    <tr></tr>
-  </thead>
-  <tbody>
-    {% for item in [
-      {"label": "Published", "value": brief.publishedAt|dateformat},
-      {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsClosedAt|datetimeformat if brief.clarificationQuestionsClosedAt is defined},
-      {"label": "Closing date for applications", "value": brief.applicationsClosedAt|datetimeformat if brief.applicationsClosedAt is defined}
-    ] %}
-      <tr class="summary-item-row">
-        <td class="summary-item-field-first"><span>{{ item.label }}</span></td>
-        <td class="summary-item-field summary-item-free-text"><span>{{ item.value }}</span></td>
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
+<h2 class="visuallyhidden">Important dates</h2>
+<dl>
+  <dt>Published</dt>
+  <dd>{{ brief.publishedAt|dateformat }}</dd>
+  <dt>Deadline for asking questions</dt>
+  <dd>{{ brief.clarificationQuestionsClosedAt|datetimeformat if brief.clarificationQuestionsClosedAt is defined }}</dd>
+  <dt>Closing date for applications</dt>
+  <dd>{{ brief.applicationsClosedAt|datetimeformat if brief.applicationsClosedAt is defined }}</dd>
+</dl>
 {% endif %}
 {% for section in content.summary(brief) %}
     {{ summary.heading(section.name, id="opportunity-attributes-{}".format(loop.index)) }}

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -15,12 +15,21 @@
      {% if section.summary_page_description %}
           {{ summary.description(section.summary_page_description) }}
         {% endif %}
-    {% call summary.mapping_table(section.name) %}
-      {% for item in section.questions %}
-        {% call summary.row() %}
-          {{ summary.field_name(item.label) }}
-          {{ summary[item.type](item.value) | format_links}}
-        {% endcall %}
-      {% endfor %}
-    {% endcall %}
+    <table class="content-table summary-item-body">
+      <caption class="visuallyhidden">
+        {{ section.name }}
+      </caption>
+      <thead class="summary-item-field-headings-visible">
+        <tr>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in section.questions %}
+          {% call summary.row() %}
+            {{ summary.field_name(item.label) }}
+            {{ summary[item.type](item.value) | format_links}}
+          {% endcall %}
+        {% endfor %}
+      </tbody>
+    </table>
 {% endfor %}

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -15,21 +15,10 @@
      {% if section.summary_page_description %}
           {{ summary.description(section.summary_page_description) }}
         {% endif %}
-    <table class="content-table summary-item-body">
-      <caption class="visuallyhidden">
-        {{ section.name }}
-      </caption>
-      <thead class="summary-item-field-headings-visible">
-        <tr>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in section.questions %}
-          <tr class="summary-item-row">
-            {{ summary.field_name(item.label) }}
-            {{ summary[item.type](item.value) | format_links}}
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <dl>
+      {% for item in section.questions %}
+        <dt>{{ summary.field_name(item.label) }}</dt>
+        <dd>{{ summary[item.type](item.value) | format_links}}</dd>
+      {% endfor %}
+    </dl>
 {% endfor %}

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -25,10 +25,10 @@
       </thead>
       <tbody>
         {% for item in section.questions %}
-          {% call summary.row() %}
+          <tr class="summary-item-row">
             {{ summary.field_name(item.label) }}
             {{ summary[item.type](item.value) | format_links}}
-          {% endcall %}
+          </tr>
         {% endfor %}
       </tbody>
     </table>

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -15,13 +15,12 @@
      {% if section.summary_page_description %}
           {{ summary.description(section.summary_page_description) }}
         {% endif %}
-    {% call(item) summary.list_table(
-      section.questions,
-      caption=section.name
-    ) %}
-      {% call summary.row() %}
-        {{ summary.field_name(item.label) }}
-        {{ summary[item.type](item.value) | format_links}}
-      {% endcall %}
+    {% call summary.mapping_table(section.name) %}
+      {% for item in section.questions %}
+        {% call summary.row() %}
+          {{ summary.field_name(item.label) }}
+          {{ summary[item.type](item.value) | format_links}}
+        {% endcall %}
+      {% endfor %}
     {% endcall %}
 {% endfor %}


### PR DESCRIPTION
To improve accessibility (so information can be read with a screenreader) on an opportunity page (e.g. http://localhost:8000/digital-marketplace/opportunities/586) it is better to use a definition list for information where it's just effectively keys and values.

This pull request just makes the minimal change to convert the tables to definition lists. I've done this as carefully as possible by steadily inlining the macros for the table creation.

However, it doesn't currently have any styling changes to go with it. I imagine you would want to style the definition lists initially to look similar visually to how the tables looked.

From conversation on Slack @matt-sm was happy for us to just do the html changes and leave the css changes in your hands.

If anything doesn't make sense here or anything needs further explanation don't hesitate to let me know.