### PR TITLE
Fix anchor id typo.

### DIFF
--- a/app/templates/content/terms-of-use/2017-02-22 12:00.html
+++ b/app/templates/content/terms-of-use/2017-02-22 12:00.html
@@ -163,7 +163,7 @@
     <p>Inquiries regarding the licence or any use of Digital Marketplace materials should be directed to:
         <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>.</p>
 </section>
-<section class="tou-section" id="indeminity">
+<section class="tou-section" id="indemnity">
     <p>
     <h2>Indemnity</h2>
     <a href="#" class="scroll-to-top">Back to top of page <b>&uarr;</b></a>


### PR DESCRIPTION
This PR: fixes the Indemnity table of contents link in the Terms of Use page, by correcting a typo in the indemnity section.