### PR TITLE
[Footer] Update terms of use, privacy, security, disclaimer and copyright links

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -87,6 +87,11 @@ def security():
     return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001027915', code=301)
 
 
+@main.route('/disclaimer')
+def disclaimer():
+    return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001028135', code=301)
+
+
 def _is_supplier_selected_for_brief(brief):
     def domain(email):
         return email.split('@')[-1]

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -77,6 +77,11 @@ def terms_of_use():
     return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001037036', code=301)
 
 
+@main.route('/privacy-policy')
+def privacy_policy():
+    return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001027895', code=301)
+
+
 def _is_supplier_selected_for_brief(brief):
     def domain(email):
         return email.split('@')[-1]

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -74,11 +74,7 @@ def content(template_name):
 
 @main.route('/terms-of-use')
 def terms_of_use():
-    terms = get_current_terms_version()
-    return render_template(
-        'content/terms-of-use/_template.html',
-        terms_content=terms.template_file,
-        update_time=terms.datetime.date())
+    return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001037036', code=301)
 
 
 def _is_supplier_selected_for_brief(brief):

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -92,6 +92,11 @@ def disclaimer():
     return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001028135', code=301)
 
 
+@main.route('/copyright')
+def copyright():
+    return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001037656', code=301)
+
+
 def _is_supplier_selected_for_brief(brief):
     def domain(email):
         return email.split('@')[-1]

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -82,6 +82,11 @@ def privacy_policy():
     return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001027895', code=301)
 
 
+@main.route('/security')
+def security():
+    return redirect('https://marketplace1.zendesk.com/hc/en-gb/articles/360001027915', code=301)
+
+
 def _is_supplier_selected_for_brief(brief):
     def domain(email):
         return email.split('@')[-1]

--- a/app/templates/_footer.html
+++ b/app/templates/_footer.html
@@ -8,19 +8,19 @@
         <a href="/contact-us">Contact us</a>
       </li>
       <li>
-        <a href="/terms-of-use">Terms of Use</a>
+        <a href="https://marketplace1.zendesk.com/hc/en-gb/articles/360001037036">Terms of Use</a>
       </li>
       <li>
-        <a href="/privacy-policy">Privacy</a>
+        <a href="https://marketplace1.zendesk.com/hc/en-gb/articles/360001027895">Privacy</a>
       </li>
       <li>
-        <a href="/security">Security</a>
+        <a href="https://marketplace1.zendesk.com/hc/en-gb/articles/360001027915">Security</a>
       </li>
       <li>
-        <a href="/disclaimer">Disclaimer</a>
+        <a href="https://marketplace1.zendesk.com/hc/en-gb/articles/360001028135">Disclaimer</a>
       </li>
       <li>
-        <a href="/copyright">Copyright</a>
+        <a href="https://marketplace1.zendesk.com/hc/en-gb/articles/360001037656">Copyright</a>
       </li>
     </ul>
     <div class="au-footer__end">

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -87,11 +87,7 @@ class TestStaticMarketplacePages(BaseApplicationTest):
 
     def test_toc_page(self):
         res = self.client.get(self.expand_path('/terms-of-use'))
-        assert_equal(200, res.status_code)
-        assert_true(
-            'TermsofUse'
-            in self._strip_whitespace(res.get_data(as_text=True))
-        )
+        assert_equal(301, res.status_code)
 
 
 class TestBriefPage(BaseApplicationTest):


### PR DESCRIPTION
This pull request updates footer links so they point to the new Zendesk pages.  It also adds redirects for the old routes.

Addresses MAR-3320