### PR TITLE
Bump boto package versions to match what utils is using

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ backoff==1.4.0
 backports.functools-lru-cache==1.5
 blessings==1.6
 blinker==1.4
-boto==2.46.1
-boto3==1.4.4
-botocore==1.5.34
+boto==2.49.0
+boto3==1.9.19
+botocore==1.12.19
 browsermob-proxy==0.8.0
 cairocffi==0.8.0
 CairoSVG==1.0.22


### PR DESCRIPTION
I ran into a problem where I couldn't upload files locally when testing the application flow. I discovered that the utils repository was running later versions of the boto packages. This pull request updates the boto packages to make them consistent with what utils is running.