### PR TITLE
Check seller_type before calling the keys function

### DIFF
--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -228,7 +228,7 @@ def supplier_search():
         seller_type = details.get('seller_type', {})
 
         is_recruiter = details.get('is_recruiter', False)
-        if is_recruiter == 'true' and 'recruiter' not in seller_type.keys():
+        if is_recruiter == 'true' and seller_type and 'recruiter' not in seller_type.keys():
             seller_type['recruitment'] = True
 
         result = {


### PR DESCRIPTION
`AttributeError: 'NoneType' object has no attribute 'keys'` is triggered when searching for sellers in the seller catalogue and a seller is returned without `seller_type`.  This pull request fixes this by checking for `seller_type` before the call to the `keys` function.

Addresses MAR-4286